### PR TITLE
Resolve instance from container

### DIFF
--- a/src/DiscordChannelServiceProvider.php
+++ b/src/DiscordChannelServiceProvider.php
@@ -18,7 +18,7 @@ class DiscordChannelServiceProvider extends ServiceProvider
     {
         Notification::resolved(function (ChannelManager $service) {
             $service->extend('discord', function ($app) {
-                return new Channels\DiscordWebhookChannel($app->make(HttpClient::class));
+                return $app->make(Channels\DiscordWebhookChannel::class);
             });
         });
     }


### PR DESCRIPTION
This allows applications to customize the HTTP client used by the channel.

For instance, I might want to set a 10 second timeout specifically on the Discord notifications channel, but not for other channels.

I can now do this in my app service provider.

```php
$this->app->when(DiscordWebhookChannel::class)
    ->needs(Client::class)
    ->give(fn () => new Client(['timeout' => 10]));

```